### PR TITLE
:us: to :uk: consistency

### DIFF
--- a/Payments/authorizenet/upload/admin/language/en-GB/payment/authorizenet_aim.php
+++ b/Payments/authorizenet/upload/admin/language/en-GB/payment/authorizenet_aim.php
@@ -14,7 +14,7 @@ $_['text_success']          = 'Success: You have modified Authorize.Net (AIM) ac
 $_['text_edit']             = 'Edit Authorize.Net (AIM)';
 $_['text_test']             = 'Test';
 $_['text_live']             = 'Live';
-$_['text_authorization']    = 'Authorization';
+$_['text_authorization']    = 'Authorisation';
 $_['text_capture']          = 'Capture';
 $_['text_authorizenet_aim'] = '<a onclick="window.open(\'http://reseller.authorize.net/application/?id=5561142\');"><img src="view/image/payment/authorizenet.png" alt="Authorize.Net" title="Authorize.Net" style="border: 1px solid #EEEEEE;" /></a>';
 


### PR DESCRIPTION
Language consistency from :us: to :uk:
'Authorization' turns to 'Authorisation'

On code review