### PR TITLE
FedEx - Improved Error Display

### DIFF
--- a/Shippings/fedex/upload/catalog/model/shipping/fedex.php
+++ b/Shippings/fedex/upload/catalog/model/shipping/fedex.php
@@ -165,6 +165,10 @@ class ModelShippingFedex extends Model
 
             if ($dom->getElementsByTagName('HighestSeverity')->item(0)->nodeValue == 'FAILURE' || $dom->getElementsByTagName('HighestSeverity')->item(0)->nodeValue == 'ERROR') {
                 $error = $dom->getElementsByTagName('HighestSeverity')->item(0)->nodeValue;
+                $error .= ' - Code: ';
+                $error .= $dom->getElementsByTagName('Code')->item(0)->nodeValue;
+                $error .= '<br />';
+                $error .= $dom->getElementsByTagName('Message')->item(0)->nodeValue;
 
                 $this->log->write('FEDEX :: ' . $response);
             } else {


### PR DESCRIPTION
Instead of just displaying ERROR or FAILURE, we also display the error code and message returned by FedEX.

![fedex_error_display](https://cloud.githubusercontent.com/assets/858132/19625579/3c77a9b0-9925-11e6-8513-55a1e96a1bb6.png)
